### PR TITLE
fixes gcc warning on syntax safeint ambiguous template <> signs

### DIFF
--- a/include/fc/safe.hpp
+++ b/include/fc/safe.hpp
@@ -119,7 +119,7 @@ namespace fc {
       {
           if( b.value > 0 && a.value < (std::numeric_limits<T>::min() + b.value) )
              FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
-          if( b.value < 0 && a.value > (std::numeric_limits<T>::max() + b.value) )
+          if( (b.value < 0) && (a.value > (std::numeric_limits<T>::max() + b.value)) )
              FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
           return safe( a.value - b.value );
       }


### PR DESCRIPTION
by the way, the other fix - with `b.template value` - seems to trigger a gcc bug (as noted on a branch `bug_in_gcc_on_debian_template_safeint_syntax` here)

so using this fix instead